### PR TITLE
[fix] 사용자 위치 미허용시 중심 위치 서울 중구로 수정

### DIFF
--- a/src/hooks/Map/useGetUserLocation.tsx
+++ b/src/hooks/Map/useGetUserLocation.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { TUserLatLng } from "../pages/Arts/Map/types";
+import { TUserLatLng } from "../../pages/Arts/Map/types";
 import { useQuery } from "@tanstack/react-query";
-import CACHE_KEYS from "../services/cacheKeys";
-import { getUserAddress } from "../services/map";
+import CACHE_KEYS from "../../services/cacheKeys";
+import { getUserAddress } from "../../services/map";
 
 const useGetUserLocation = () => {
   const [userLatLng, setUserLatLng] = useState<TUserLatLng>(initialLocation);
@@ -26,7 +26,8 @@ const useGetUserLocation = () => {
 
 export default useGetUserLocation;
 
+// 위치 미허용시 중심 위치 - 서울특별시청 기준 (서울 중구)
 const initialLocation = {
-  lat: 33.450701,
-  lng: 126.570667
+  lat: 37.566295,
+  lng: 126.977945
 };

--- a/src/pages/Arts/Map/index.tsx
+++ b/src/pages/Arts/Map/index.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import useArtsOnMap from "../../../hooks/Map/useArtsOnMap";
-import useGetUserLocation from "../../../hooks/useGetUserLocation";
+import useGetUserLocation from "../../../hooks/Map/useGetUserLocation";
 import { TMapProps, TUserLatLng } from "./types";
 import MapView from "./View";
 import { useEffect, useState } from "react";


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 현재 샘플 데이터 모두 서울시 기준으로, 사용지 위치 미허용시 중심 위치를 서울 중구로 변경 
(서울특별시청의 위경도)
